### PR TITLE
Fixed deadlink due to spelling mistake

### DIFF
--- a/auto-diagram-app/README.md
+++ b/auto-diagram-app/README.md
@@ -27,7 +27,7 @@ Creating a layer of automation for diagram creation
 ## Front-end dev resources for developing the diagram
 
 - https://learnlayout.com/
-- https://vuesjs.org/v2/guide/index.html
+- https://vuejs.org/v2/guide/index.html
 - https://github.com/axios/axios
 - https://www.npmjs.com/package/live-server
 - https://cssgrid.io/


### PR DESCRIPTION
### What does this PR do?
The vuejs link has a spelling mistake, this corrects it.

### How should this be tested?
Click on the link on master, see a 404.
Click on the link in the PR, see the page.

### Is there a relevant Issue open for this?
No.

### Other Relevant info, PRs, etc.
None.

### People to notify
cc: @redhat-cop/auto-docs
